### PR TITLE
Add Isso support

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -68,6 +68,17 @@ into the {body} of the default.hbs template --}}
 
                 {{/author}}
             </footer>
+            
+            {{!--
+  
+            If you use Isso comments, just uncomment this block.
+            The only thing you need to change is "comments.example.com" - which
+            should be replaced with your own Isso domain name.
+ 
+            <section class="post-full-comments" id="isso-thread">
+                <script data-isso="https://comments.example.com" data-isso-lang="en" src="https://comments.example.com/js/embed.min.js"></script>
+            </section>
+            --}}
 
             {{!--
 


### PR DESCRIPTION
Add Isso support, so Ghost users will be able to use either Disqus (proprietary) or Isso (open source). Using a commenting system like Isso will be much faster to enable after a `ghost update`.