### PR TITLE
no parenthesis around (name) in translation helper

### DIFF
--- a/partials/byline-multiple.hbs
+++ b/partials/byline-multiple.hbs
@@ -21,7 +21,7 @@
                 <div class="bio">
                     {{#if bio}}
                         <p>{{bio}}</p>
-                        <p>{{{t "<a href='{url}'>More posts</a> by {name}" url=(url) name=(name)}}}.</p>
+                        <p>{{{t "<a href='{url}'>More posts</a> by {name}" url=(url) name=name}}}.</p>
                     {{else}}
                         <p>{{{t "Read <a href='{url}'>more posts</a> by this author" url=(url)}}}.</p>
                     {{/if}}


### PR DESCRIPTION
fixes #12