### PR TITLE
Change proposition for collaboration articles

### DIFF
--- a/locales/fr.json
+++ b/locales/fr.json
@@ -22,7 +22,7 @@
     "See all % posts": "Voir les % articles",
     "Share this": "Partager",
     "Stay up to date! Get all the latest & greatest posts delivered straight to your inbox": "Restez à jour ! Recevez tous les derniers articles directement dans votre boîte aux lettres.",
-    "This post was a collaboration between": "Cet article est le fruit d’une collaboration entre",
+    "This post was a collaboration between": "Cet article est une collaboration entre",
     "youremail@example.com": "votreemail@exemple.fr",
     "1 post": "Un article",
     "% posts": "% articles",


### PR DESCRIPTION
Je propose de passer la traduction de "This post was a collaboration between" à "Cet article est une collaboration entre", qui est moins lourde que la tournure "est le fruit" et plus fidèle au texte original.